### PR TITLE
Add test for database initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Investimentos
+
+Este projeto utiliza SQLite e Streamlit para gerenciar investimentos.
+
+## Executando os testes
+
+Para rodar os testes unitários, execute o seguinte comando na raiz do projeto:
+
+```bash
+pytest
+```

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,18 @@
+import sqlite3
+import db
+
+# Para executar os testes, rode `pytest` na raiz do projeto.
+
+def test_initialize_db_creates_tables(tmp_path):
+    # Usa um arquivo SQLite temporário para não interferir em dados reais
+    db.DB_PATH = str(tmp_path / "test_investments.db")
+    db.initialize_db()
+
+    conn = sqlite3.connect(db.DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {row[0] for row in cursor.fetchall()}
+    expected = {"users", "portfolio", "asset_classes", "favorites", "user_logs"}
+    for table in expected:
+        assert table in tables
+    conn.close()


### PR DESCRIPTION
## Summary
- add database initialization test
- provide instructions for running tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e9f5274883228c25b7c5e3874c19