### PR TITLE
Add allocation rules and percent targets

### DIFF
--- a/db.py
+++ b/db.py
@@ -35,6 +35,7 @@ def initialize_db():
                 asset_name TEXT NOT NULL,
                 asset_class TEXT,
                 target_percent REAL NOT NULL,
+                quantity REAL NOT NULL DEFAULT 0.0,
                 current_value REAL NOT NULL
             );
         """)
@@ -44,7 +45,7 @@ def initialize_db():
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username TEXT NOT NULL,
                 class_name TEXT NOT NULL,
-                target_value REAL NOT NULL DEFAULT 0.0
+                target_percent REAL NOT NULL DEFAULT 0.0
             );
         """)
         # Favoritos
@@ -66,4 +67,15 @@ def initialize_db():
                 timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
             );
         """)
+    # Verifica se as colunas extras existem e cria caso contrário
+    cur = conn.execute("PRAGMA table_info(portfolio)")
+    cols = {row[1] for row in cur.fetchall()}
+    if "quantity" not in cols:
+        conn.execute("ALTER TABLE portfolio ADD COLUMN quantity REAL NOT NULL DEFAULT 0.0")
+
+    cur = conn.execute("PRAGMA table_info(asset_classes)")
+    cols = {row[1] for row in cur.fetchall()}
+    if "target_percent" not in cols:
+        conn.execute("ALTER TABLE asset_classes ADD COLUMN target_percent REAL NOT NULL DEFAULT 0.0")
+
     conn.close()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -18,4 +18,12 @@ def test_initialize_db_creates_tables(tmp_path):
     expected = {"users", "portfolio", "asset_classes", "favorites", "user_logs"}
     for table in expected:
         assert table in tables
+
+    cursor.execute("PRAGMA table_info(portfolio)")
+    portfolio_cols = {row[1] for row in cursor.fetchall()}
+    assert "quantity" in portfolio_cols
+
+    cursor.execute("PRAGMA table_info(asset_classes)")
+    asset_cols = {row[1] for row in cursor.fetchall()}
+    assert "target_percent" in asset_cols
     conn.close()


### PR DESCRIPTION
## Summary
- update database schema for new quantity and target percent columns
- enforce 5% allocation limit per asset in portfolio view
- allow target allocation percentage per asset class
- adjust reports and simulations to use new target percent
- test new columns created in initialization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848225a006883228b9350e1ede670d1