### PR TITLE
Improve quote search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Para rodar os testes unitários, execute o seguinte comando na raiz do projeto:
 ```bash
 pytest
 ```
+
+## Consulta de Cotações
+
+Na aba **Cotações** é possível buscar ativos informando o ticker ou o nome da
+empresa/fundo. O aplicativo irá listar os resultados encontrados e exibir a
+cotação atual, permitindo adicionar o ativo aos favoritos.


### PR DESCRIPTION
## Summary
- search tickers by company name with `yf.search`
- display multiple results and allow adding to favorites
- document quote search usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684823f7cf608322baaea466696f277a